### PR TITLE
Use a single visitor. Collect all parsing errors and log each one.

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -9,7 +9,7 @@ use std::{
     collections::{hash_map::Entry, HashMap, HashSet},
     fs,
     ops::Not,
-    path::Path,
+    path::{Path, PathBuf},
 };
 #[cfg(feature = "go")]
 use typeshare_core::language::Go;
@@ -329,7 +329,7 @@ fn main() -> Result<(), ()> {
 
 /// Input data for parsing each source file.
 struct ParserInput {
-    file_path: String,
+    file_path: PathBuf,
     file_name: String,
     crate_name: String,
 }
@@ -345,7 +345,7 @@ fn parser_inputs(
         .filter_map(|dir_entry| {
             let extension = language_type.language_extension();
             let crate_name = determine_crate_name(dir_entry.path())?;
-            let file_path = dir_entry.path().to_str().map(String::from)?;
+            let file_path = dir_entry.path().to_path_buf();
             let file_name = format!("{crate_name}.{extension}");
             Some(ParserInput {
                 file_path,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -6,7 +6,7 @@ use config::Config;
 use ignore::{overrides::OverrideBuilder, types::TypesBuilder, WalkBuilder};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::{
-    collections::{hash_map::Entry, HashMap},
+    collections::{hash_map::Entry, HashMap, HashSet},
     fs,
     ops::Not,
     path::Path,
@@ -367,13 +367,13 @@ fn parser_inputs(
 
 /// Collect all the typeshared types into a mapping of crate names to typeshared types. This
 /// mapping is used to lookup and generated import statements for generated files.
-fn all_types(file_mappings: &HashMap<String, ParsedData>) -> HashMap<String, Vec<String>> {
+fn all_types(file_mappings: &HashMap<String, ParsedData>) -> HashMap<String, HashSet<String>> {
     file_mappings
         .iter()
         .map(|(crate_name, parsed_data)| (crate_name, parsed_data.type_names.clone()))
         .fold(
             HashMap::new(),
-            |mut import_map: HashMap<String, Vec<String>>, (crate_name, type_names)| {
+            |mut import_map: HashMap<String, HashSet<String>>, (crate_name, type_names)| {
                 match import_map.entry(crate_name.clone()) {
                     Entry::Occupied(mut e) => {
                         e.get_mut().extend(type_names);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -403,7 +403,7 @@ fn parse_input(inputs: Vec<ParserInput>) -> HashMap<String, ParsedData> {
                     &data,
                     crate_name.clone(),
                     file_name.clone(),
-                    &file_path,
+                    file_path,
                 );
                 match parsed_data {
                     Ok(data) => {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -399,8 +399,12 @@ fn parse_input(inputs: Vec<ParserInput>) -> HashMap<String, ParsedData> {
              }| {
                 let data = std::fs::read_to_string(&file_path)
                     .unwrap_or_else(|e| panic!("failed to read file at {file_path:?}: {e}", e = e));
-                let parsed_data =
-                    typeshare_core::parser::parse(&data, crate_name.clone(), file_name.clone());
+                let parsed_data = typeshare_core::parser::parse(
+                    &data,
+                    crate_name.clone(),
+                    file_name.clone(),
+                    &file_path,
+                );
                 match parsed_data {
                     Ok(data) => {
                         data.and_then(|d| is_parsed_data_empty(&d).not().then(|| (crate_name, d)))

--- a/core/src/language/go.rs
+++ b/core/src/language/go.rs
@@ -29,7 +29,7 @@ impl Language for Go {
     fn generate_types(
         &mut self,
         w: &mut dyn Write,
-        _imports: &HashMap<String, Vec<String>>,
+        _imports: &HashMap<String, HashSet<String>>,
         data: &ParsedData,
     ) -> std::io::Result<()> {
         // Generate a list of all types that either are a struct or are aliased to a struct.

--- a/core/src/language/mod.rs
+++ b/core/src/language/mod.rs
@@ -358,7 +358,17 @@ fn used_imports<'a, 'b: 'a>(
                         entry.insert(BTreeSet::from([ty_name.as_str()]));
                     }
                 }
+            } else {
+                eprintln!(
+                    "Could not lookup referenced type \"{}\" in module \"{}\" when generating module \"{}\"",
+                    referenced_import.type_name, referenced_import.base_crate, data.crate_name
+                );
             }
+        } else {
+            // eprintln!(
+            //     "Could not lookup referenced crate module \"{}\" when generating module \"{}\"",
+            //     referenced_import.base_crate, data.crate_name
+            // );
         }
     }
     used_imports

--- a/core/src/language/mod.rs
+++ b/core/src/language/mod.rs
@@ -376,8 +376,8 @@ fn used_imports<'a, 'b: 'a>(
             }
         } else {
             // println!(
-            //     "Could not lookup referenced crate module \"{}\" when generating module \"{}\"",
-            //     referenced_import.base_crate, data.crate_name
+            //     "Could not lookup referenced crate module \"{}\" for type \"{}\" when generating module \"{}\"",
+            //     referenced_import.base_crate, referenced_import.type_name, data.crate_name
             // );
         }
     }

--- a/core/src/language/mod.rs
+++ b/core/src/language/mod.rs
@@ -6,7 +6,7 @@ use crate::{
 use itertools::Itertools;
 use proc_macro2::Ident;
 use std::{
-    collections::{btree_map::Entry, BTreeMap, BTreeSet, HashMap},
+    collections::{btree_map::Entry, BTreeMap, BTreeSet, HashMap, HashSet},
     io::Write,
     str::FromStr,
 };
@@ -78,7 +78,7 @@ pub trait Language {
     fn generate_types(
         &mut self,
         writable: &mut dyn Write,
-        all_types: &HashMap<String, Vec<String>>,
+        all_types: &HashMap<String, HashSet<String>>,
         data: &ParsedData,
     ) -> std::io::Result<()> {
         self.begin_file(writable, data)?;
@@ -324,7 +324,7 @@ pub trait Language {
 /// a list of imports for the generated module.
 fn used_imports<'a, 'b: 'a>(
     data: &'b ParsedData,
-    all_types: &'a HashMap<String, Vec<String>>,
+    all_types: &'a HashMap<String, HashSet<String>>,
 ) -> BTreeMap<&'a str, BTreeSet<&'a str>> {
     let mut used_imports: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
 

--- a/core/src/language/mod.rs
+++ b/core/src/language/mod.rs
@@ -328,7 +328,7 @@ fn used_imports<'a, 'b: 'a>(
 ) -> BTreeMap<&'a str, BTreeSet<&'a str>> {
     let mut used_imports: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
 
-    for referenced_import in data.import_types.iter() {
+    for referenced_import in &data.import_types {
         // Skip over imports that reference the current crate. They
         // are all collapsed into one module per crate.
         if data.crate_name == referenced_import.base_crate {
@@ -359,13 +359,13 @@ fn used_imports<'a, 'b: 'a>(
                     }
                 }
             } else {
-                eprintln!(
+                println!(
                     "Could not lookup referenced type \"{}\" in module \"{}\" when generating module \"{}\"",
                     referenced_import.type_name, referenced_import.base_crate, data.crate_name
                 );
             }
         } else {
-            // eprintln!(
+            // println!(
             //     "Could not lookup referenced crate module \"{}\" when generating module \"{}\"",
             //     referenced_import.base_crate, data.crate_name
             // );

--- a/core/src/language/scala.rs
+++ b/core/src/language/scala.rs
@@ -6,6 +6,7 @@ use crate::rust_types::{RustType, RustTypeFormatError, SpecialRustType};
 use itertools::Itertools;
 use joinery::JoinableIterator;
 use lazy_format::lazy_format;
+use std::collections::HashSet;
 use std::ops::Deref;
 use std::{collections::HashMap, io::Write};
 
@@ -27,7 +28,7 @@ impl Language for Scala {
     fn generate_types(
         &mut self,
         writable: &mut dyn Write,
-        _imports: &HashMap<String, Vec<String>>,
+        _imports: &HashMap<String, HashSet<String>>,
         data: &ParsedData,
     ) -> std::io::Result<()> {
         self.begin_file(writable, data)?;

--- a/core/src/language/typescript.rs
+++ b/core/src/language/typescript.rs
@@ -1,14 +1,17 @@
-use crate::parser::ParsedData;
-use crate::rust_types::{RustType, RustTypeFormatError, SpecialRustType};
 use crate::{
     language::{Language, SupportedLanguage},
-    rust_types::{RustEnum, RustEnumVariant, RustField, RustStruct, RustTypeAlias},
+    parser::ParsedData,
+    rust_types::{
+        RustEnum, RustEnumVariant, RustField, RustStruct, RustType, RustTypeAlias,
+        RustTypeFormatError, SpecialRustType,
+    },
 };
 use itertools::Itertools;
 use joinery::JoinableIterator;
-use std::collections::{BTreeMap, BTreeSet};
-use std::io;
-use std::{collections::HashMap, io::Write};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    io::{self, Write},
+};
 
 /// All information needed to generate Typescript type-code
 #[derive(Default)]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -2,7 +2,10 @@
 //! Contains the parser and language converters.
 
 use language::Language;
-use std::{collections::HashMap, io::Write};
+use std::{
+    collections::{HashMap, HashSet},
+    io::Write,
+};
 use thiserror::Error;
 
 mod rename;
@@ -29,7 +32,7 @@ pub enum ProcessInputError {
 pub fn process_input(
     input: &str,
     language: &mut dyn Language,
-    imports: &HashMap<String, Vec<String>>,
+    imports: &HashMap<String, HashSet<String>>,
     out: &mut dyn Write,
 ) -> Result<(), ProcessInputError> {
     let parsed_data = parser::parse(input, "default_name".into(), "file_name".into())?;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -35,7 +35,12 @@ pub fn process_input(
     imports: &HashMap<String, HashSet<String>>,
     out: &mut dyn Write,
 ) -> Result<(), ProcessInputError> {
-    let parsed_data = parser::parse(input, "default_name".into(), "file_name".into())?;
+    let parsed_data = parser::parse(
+        input,
+        "default_name".into(),
+        "file_name".into(),
+        "file_path",
+    )?;
     language.generate_types(out, imports, &parsed_data.unwrap())?;
     Ok(())
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -39,7 +39,7 @@ pub fn process_input(
         input,
         "default_name".into(),
         "file_name".into(),
-        "file_path",
+        "file_path".into(),
     )?;
     language.generate_types(out, imports, &parsed_data.unwrap())?;
     Ok(())

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -80,6 +80,8 @@ pub struct ParsedData {
     pub type_names: HashSet<String>,
     /// Failures during parsing.
     pub errors: Vec<ErrorInfo>,
+    /// Usefull for logging/debugging.
+    pub file_path: String,
 }
 
 pub struct ParsedModule {
@@ -87,10 +89,11 @@ pub struct ParsedModule {
 }
 
 impl ParsedData {
-    pub fn new(crate_name: String, file_name: String) -> Self {
+    pub fn new(crate_name: String, file_name: String, file_path: String) -> Self {
         Self {
             crate_name,
             file_name,
+            file_path,
             ..Default::default()
         }
     }
@@ -175,8 +178,8 @@ impl ParsedData {
 
             if found.is_none() {
                 println!(
-                    "Failed to lookup \"{name}\" in crate \"{}\"",
-                    self.crate_name
+                    "Failed to lookup \"{name}\" in crate \"{}\" for file \"{}\"",
+                    self.crate_name, self.file_path
                 );
             }
 
@@ -203,7 +206,7 @@ pub fn parse(
     input: &str,
     crate_name: String,
     file_name: String,
-    file_path: &str,
+    file_path: String,
 ) -> Result<Option<ParsedData>, ParseError> {
     // We will only produce output for files that contain the `#[typeshare]`
     // attribute, so this is a quick and easy performance win
@@ -211,11 +214,11 @@ pub fn parse(
         return Ok(None);
     }
 
-    println!("Parsing {file_path}");
+    // println!("Parsing {file_path}");
 
     // Parse and process the input, ensuring we parse only items marked with
     // `#[typeshare]`
-    let mut import_visitor = TypeShareVisitor::new(crate_name, file_name);
+    let mut import_visitor = TypeShareVisitor::new(crate_name, file_name, file_path);
     import_visitor.visit_file(&syn::parse_file(input)?);
 
     let mut parsed_data = import_visitor.parsed_data();

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -183,7 +183,8 @@ impl ParsedData {
             found
         };
 
-        // Lookup all the references that are not defined locally.
+        // Lookup all the references that are not defined locally. Subtract
+        // all local types defined in the module.
         let mut diff = all_references
             .difference(&local_types)
             .copied()
@@ -202,20 +203,20 @@ pub fn parse(
     input: &str,
     crate_name: String,
     file_name: String,
+    file_path: &str,
 ) -> Result<Option<ParsedData>, ParseError> {
     // We will only produce output for files that contain the `#[typeshare]`
     // attribute, so this is a quick and easy performance win
-    if !input.contains(TYPESHARE) {
+    if !input.contains("#[typeshare") {
         return Ok(None);
     }
 
-    // let mut parsed_data = ParsedData::new(crate_name.clone(), file_name);
+    println!("Parsing {file_path}");
+
     // Parse and process the input, ensuring we parse only items marked with
     // `#[typeshare]`
-    let source = syn::parse_file(input)?;
-
     let mut import_visitor = TypeShareVisitor::new(crate_name, file_name);
-    import_visitor.visit_file(&source);
+    import_visitor.visit_file(&syn::parse_file(input)?);
 
     let mut parsed_data = import_visitor.parsed_data();
     parsed_data.reconcile_referenced_types();

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -360,8 +360,8 @@ impl RustType {
     }
 
     /// Yield all the type names including nested generic types.
-    pub fn all_names(&self) -> impl Iterator<Item = &'_ str> + '_ {
-        RustGenTypeIter {
+    pub fn all_reference_type_names(&self) -> impl Iterator<Item = &'_ str> + '_ {
+        RustRefTypeIter {
             ty: Some(self),
             parameters: Vec::new(),
         }
@@ -369,12 +369,12 @@ impl RustType {
     }
 }
 
-struct RustGenTypeIter<'a> {
+struct RustRefTypeIter<'a> {
     ty: Option<&'a RustType>,
     parameters: Vec<&'a RustType>,
 }
 
-impl<'a> Iterator for RustGenTypeIter<'a> {
+impl<'a> Iterator for RustRefTypeIter<'a> {
     type Item = &'a str;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -6,6 +6,7 @@ use syn::{Expr, ExprLit, Lit, TypeArray, TypeSlice};
 use thiserror::Error;
 
 use crate::language::SupportedLanguage;
+use crate::visitors::accept_type;
 
 /// Identifier used in Rust structs, enums, and fields. It includes the `original` name and the `renamed` value after the transformation based on `serde` attributes.
 #[derive(Debug, Clone, PartialEq)]
@@ -364,7 +365,7 @@ impl RustType {
             ty: Some(self),
             parameters: Vec::new(),
         }
-        .filter(|&s| s != "String" && s != "Option" && s != "Vec" && s != "HashMap")
+        .filter(|s| accept_type(s))
     }
 }
 

--- a/core/src/visitors.rs
+++ b/core/src/visitors.rs
@@ -77,6 +77,20 @@ impl<'ast> Visit<'ast> for TypeShareVisitor {
     /// the `use` import statements.
     fn visit_path(&mut self, p: &'ast syn::Path) {
         fn extract_root_and_types(p: &syn::Path, crate_name: &str) -> Option<ImportedType> {
+            // TODO: the first part here may not be a crate name but a module name defined
+            // in a use statement.
+            //
+            // Ex:
+            // use some_crate::some_module;
+            //
+            // struct SomeType {
+            //     field: some_module::RefType
+            // }
+            //
+            // vist_path would be after vist_item_use so we could retain imported module references
+            // and reconcile aftewards. visit_item_use would have to retain not type import types
+            // which it discards right now.
+            //
             let first = p.segments.first()?.ident.to_string();
             let last = p.segments.last()?.ident.to_string();
 

--- a/core/src/visitors.rs
+++ b/core/src/visitors.rs
@@ -35,7 +35,7 @@ const IGNORED_BASE_CRATES: &[&str] = &[
     "neon",
 ];
 
-const IGNORED_TYPES: &[&str] = &["Option", "String", "Vec", "HashMap"];
+const IGNORED_TYPES: &[&str] = &["Option", "String", "Vec", "HashMap", "T", "I54", "U53"];
 
 /// An import visitor that collects all use or
 /// qualified referenced items.

--- a/core/src/visitors.rs
+++ b/core/src/visitors.rs
@@ -100,7 +100,7 @@ impl<'ast> Visit<'ast> for TypeShareVisitor {
 
             (first != last).then(|| {
                 // resolve crate and super aliases into the crate name.
-                let base_crate = if first == "crate" || first == "super" {
+                let base_crate = if first == "crate" || first == "super" || first == "self" {
                     crate_name.to_string()
                 } else {
                     first
@@ -201,7 +201,7 @@ impl<'a> ItemUseIter<'a> {
 
     fn resolve_crate_name(&self) -> String {
         let crate_name = self.base_name();
-        if crate_name == "crate" || crate_name == "super" {
+        if crate_name == "crate" || crate_name == "super" || crate_name == "self" {
             self.crate_name.to_string()
         } else {
             crate_name.to_string()

--- a/core/src/visitors.rs
+++ b/core/src/visitors.rs
@@ -46,9 +46,9 @@ pub struct TypeShareVisitor {
 
 impl TypeShareVisitor {
     /// Create an import visitor for a given crate name.
-    pub fn new(crate_name: String, file_name: String) -> Self {
+    pub fn new(crate_name: String, file_name: String, file_path: String) -> Self {
         Self {
-            parsed_data: ParsedData::new(crate_name, file_name),
+            parsed_data: ParsedData::new(crate_name, file_name, file_path),
         }
     }
 
@@ -388,7 +388,8 @@ mod test {
             ";
 
         let file: File = syn::parse_str(rust_code).unwrap();
-        let mut visitor = TypeShareVisitor::new("my_crate".into(), "my_file".into());
+        let mut visitor =
+            TypeShareVisitor::new("my_crate".into(), "my_file".into(), "file_path".into());
         visitor.visit_file(&file);
 
         assert_matches!(

--- a/core/tests/snapshot_tests.rs
+++ b/core/tests/snapshot_tests.rs
@@ -71,7 +71,7 @@ fn check(
         &rust_input,
         "default_crate".into(),
         "file_name".into(),
-        "file_path",
+        "file_path".into(),
     )?
     .unwrap();
     lang.generate_types(&mut typeshare_output, &HashMap::new(), &parsed_data)?;

--- a/core/tests/snapshot_tests.rs
+++ b/core/tests/snapshot_tests.rs
@@ -67,9 +67,13 @@ fn check(
     )?;
 
     let mut typeshare_output: Vec<u8> = Vec::new();
-    let parsed_data =
-        typeshare_core::parser::parse(&rust_input, "default_crate".into(), "file_name".into())?
-            .unwrap();
+    let parsed_data = typeshare_core::parser::parse(
+        &rust_input,
+        "default_crate".into(),
+        "file_name".into(),
+        "file_path",
+    )?
+    .unwrap();
     lang.generate_types(&mut typeshare_output, &HashMap::new(), &parsed_data)?;
 
     let typeshare_output = String::from_utf8(typeshare_output)?;


### PR DESCRIPTION
With the introduction of the `Visit` impl this MR moves all parsing into the trait impl. This also collects all errors and displays them.

Optimize import resolution.